### PR TITLE
Fix coverage reporting and clean-up CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
         features:
           - 'default'
-          - 'cgmath'
+          - ''
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, ci ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, ci ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - 1.44.0
 
         features:
-          - '--no-default-features'
-          - '--features "cgmath"'
+          - 'default'
+          - 'cgmath'
 
     steps:
     - name: Checkout
@@ -37,10 +37,16 @@ jobs:
         override: true
 
     - name: Build
-      run: cargo build --verbose ${{ matrix.features }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --verbose --no-default-features --features "${{ matrix.features }}"
 
     - name: Run tests
-      run: cargo test --verbose ${{ matrix.features }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --verbose --no-default-features --features "${{ matrix.features }}"
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ci ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  test:
+    name: Test
     runs-on: ubuntu-latest
 
     strategy:
@@ -41,13 +42,28 @@ jobs:
     - name: Run tests
       run: cargo test --verbose ${{ matrix.features }}
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install rust (stable)
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
     - name: Install cargo-tarpaulin
       run: |
         RUST_BACKTRACE=1 cargo install --version 0.16.0 cargo-tarpaulin
 
     - name: Generate code coverage
       run: |
-        RUST_BACKTRACE=1 cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Lcov
+        RUST_BACKTRACE=1 cargo tarpaulin --verbose --workspace --timeout 120 --out Lcov --no-default-features --config tarpaulin.toml
         ls -la
 
     - name: Upload code coverage
@@ -55,3 +71,24 @@ jobs:
       with:
         path-to-lcov: './lcov.info'
         github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  doc:
+    name: Build documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust (stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --verbose --features "default"

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,8 @@
+[default_coverage]
+features = "default"
+
+[builtin_math_coverage]
+features = ""
+
+[report]
+out = ["Lcov"]


### PR DESCRIPTION
Move coverage to its own CI build, instead of doing coverage per build variant,
and use a `tarpaulin.toml` config file to generate coverage for all feature
variants at once and upload those as a single report together. This fixes an
issue with Coveralls reporting `math.rs` covered at 0% due to not being used in
some builds (`default` features).

Add a documentation build to check that docs are building correctly.

Clean-up the workflow YAML to use `actions-rs` and have more meaningful (and
shorter) test build names.
