### PR TITLE
Bump min Rust version to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.44.0
+          - 1.56.0
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/djeedai/weldr/workflows/CI/badge.svg?branch=main)](https://github.com/djeedai/weldr/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/weldr/badge.svg?branch=main)](https://coveralls.io/github/djeedai/weldr?branch=main)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.44.0+-lightgray.svg)](#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56.0+-lightgray.svg)](#rust-version-requirements)
 
 weldr is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
 

--- a/bin/weldr/README.md
+++ b/bin/weldr/README.md
@@ -4,7 +4,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/weldr-bin.svg)](https://crates.io/crates/weldr-bin)
 [![CI](https://github.com/djeedai/weldr/workflows/CI/badge.svg?branch=main)](https://github.com/djeedai/weldr/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/weldr/badge.svg?branch=main)](https://coveralls.io/github/djeedai/weldr?branch=main)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.44.0+-lightgray.svg)](#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56.0+-lightgray.svg)](#rust-version-requirements)
 
 weldr is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
 
@@ -66,7 +66,7 @@ Example:
 
 ## Rust version requirements
 
-weldr is tested with `rustc` **version 1.44**, **stable**, and **beta**, although older versions may work, but have never been tested.
+weldr is tested with `rustc` **version 1.56**, **stable**, and **beta**, although older versions may work, but have never been tested.
 
 ## Copyrights
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -4,7 +4,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/weldr.svg)](https://crates.io/crates/weldr)
 [![CI](https://github.com/djeedai/weldr/workflows/CI/badge.svg?branch=main)](https://github.com/djeedai/weldr/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/weldr/badge.svg?branch=main)](https://coveralls.io/github/djeedai/weldr?branch=main)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.44.0+-lightgray.svg)](#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56.0+-lightgray.svg)](#rust-version-requirements)
 
 weldr is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
 
@@ -45,7 +45,7 @@ fn parse_ldr() {
 
 ## Rust version requirements
 
-weldr is tested with `rustc` **version 1.44**, **stable**, and **beta**, although older versions may work, but have never been tested.
+weldr is tested with `rustc` **version 1.56**, **stable**, and **beta**, although older versions may work, but have never been tested.
 
 ## Installation
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -844,7 +844,7 @@ fn load_and_parse_single_file(
 /// ```rust
 /// use weldr::{ FileRefResolver, parse, ResolveError, SourceMap };
 ///
-/// struct MyCustomResolver {};
+/// struct MyCustomResolver;
 ///
 /// impl FileRefResolver for MyCustomResolver {
 ///   fn resolve(&self, filename: &str) -> Result<Vec<u8>, ResolveError> {


### PR DESCRIPTION
Align on `nom` v7.x ahead of merging #22, and to work around issues fetching from crates.io with v1.44.