### PR TITLE
Fix hybrid file parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.60.0
+          - 1.61.0
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.58.1
+          - 1.60.0
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT or Apache 2.0](https://img.shields.io/badge/License-MIT%20or%20Apache2-blue.svg)](https://github.com/djeedai/weldr#license)
 [![CI](https://github.com/djeedai/weldr/workflows/CI/badge.svg?branch=main)](https://github.com/djeedai/weldr/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/weldr/badge.svg?branch=main)](https://coveralls.io/github/djeedai/weldr?branch=main)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.60.0+-lightgray.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.61.0+-lightgray.svg)
 
 weldr is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
 
@@ -21,8 +21,6 @@ The weldr library allows building command-line tools and applications leveraging
 Parse the content of a single LDraw file containing 2 commands:
 
 ```rust
-extern crate weldr;
-
 use weldr::{parse_raw, CommandType, CommentCmd, LineCmd, Vec3};
 
 fn main() {}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT or Apache 2.0](https://img.shields.io/badge/License-MIT%20or%20Apache2-blue.svg)](https://github.com/djeedai/weldr#license)
 [![CI](https://github.com/djeedai/weldr/workflows/CI/badge.svg?branch=main)](https://github.com/djeedai/weldr/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/weldr/badge.svg?branch=main)](https://coveralls.io/github/djeedai/weldr?branch=main)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56.0+-lightgray.svg)](#rust-version-requirements)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.60.0+-lightgray.svg)
 
 weldr is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
 

--- a/bin/weldr/src/weldr.rs
+++ b/bin/weldr/src/weldr.rs
@@ -305,6 +305,7 @@ impl GeometryCache {
     }
 
     fn add_line(&mut self, draw_ctx: &DrawContext, vertices: &[Vec3; 2]) {
+        trace!("LINE: {:?}", vertices);
         let i0 = self.insert_vertex(&vertices[0], &draw_ctx.transform);
         let i1 = self.insert_vertex(&vertices[1], &draw_ctx.transform);
         self.line_indices.push(i0);
@@ -312,6 +313,7 @@ impl GeometryCache {
     }
 
     fn add_triangle(&mut self, draw_ctx: &DrawContext, vertices: &[Vec3; 3]) {
+        trace!("TRI: {:?}", vertices);
         let i0 = self.insert_vertex(&vertices[0], &draw_ctx.transform);
         let i1 = self.insert_vertex(&vertices[1], &draw_ctx.transform);
         let i2 = self.insert_vertex(&vertices[2], &draw_ctx.transform);
@@ -321,8 +323,17 @@ impl GeometryCache {
     }
 
     fn add_quad(&mut self, draw_ctx: &DrawContext, vertices: &[Vec3; 4]) {
-        self.add_triangle(draw_ctx, &[vertices[0], vertices[1], vertices[2]]);
-        self.add_triangle(draw_ctx, &[vertices[0], vertices[2], vertices[3]]);
+        trace!("QUAD: {:?}", vertices);
+        let i0 = self.insert_vertex(&vertices[0], &draw_ctx.transform);
+        let i1 = self.insert_vertex(&vertices[1], &draw_ctx.transform);
+        let i2 = self.insert_vertex(&vertices[2], &draw_ctx.transform);
+        let i3 = self.insert_vertex(&vertices[3], &draw_ctx.transform);
+        self.triangle_indices.push(i0);
+        self.triangle_indices.push(i2);
+        self.triangle_indices.push(i1);
+        self.triangle_indices.push(i0);
+        self.triangle_indices.push(i3);
+        self.triangle_indices.push(i2);
     }
 }
 


### PR DESCRIPTION
Fix parsing hybrid files containing both drawing commands and sub-file references. Stop trying to guess based on sub-file extension.

Fixes #32