### PR TITLE
Update README, CHANGELOGs, add MSRV to Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,23 @@
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/weldr/badge.svg?branch=main)](https://coveralls.io/github/djeedai/weldr?branch=main)
 ![Minimum rustc version](https://img.shields.io/badge/rustc-1.61.0+-lightgray.svg)
 
-weldr is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
+**weldr** is a Rust library and command-line tool to manipulate [LDraw](https://www.ldraw.org/) files ([format specification](https://www.ldraw.org/article/218.html)), which are files describing 3D models of [LEGO®](http://www.lego.com)* pieces.
 
 This repository is a Cargo workspace composed of the following packages:
 
-| Crate | Version | Description | Path |
+| Package | Version | Description | Path |
 |---|---|---|---|
 | [📦 `weldr`](https://crates.io/crates/weldr) | [![Crates.io Version](https://img.shields.io/crates/v/weldr.svg)](https://crates.io/crates/weldr) | The weldr Rust library | [`lib/`](./lib) |
 | [📦 `weldr-bin`](https://crates.io/crates/weldr-bin) | [![Crates.io Version](https://img.shields.io/crates/v/weldr-bin.svg)](https://crates.io/crates/weldr-bin) | The ⚙ `weldr` command-line tool | [`bin/weldr/`](./bin/weldr) |
 
 ## Library
 
-The weldr library allows building command-line tools and applications leveraging [the fantastic database of pieces](https://www.ldraw.org/cgi-bin/ptlist.cgi) contributed by the LDraw community.
+The `weldr` library allows building command-line tools and applications leveraging [the fantastic database of pieces](https://library.ldraw.org/) contributed by the LDraw community.
 
 Parse the content of a single LDraw file containing 2 commands:
 
 ```rust
-use weldr::{parse_raw, CommandType, CommentCmd, LineCmd, Vec3};
-
-fn main() {}
+use weldr::*;
 
 #[test]
 fn test_weldr() {
@@ -46,7 +44,7 @@ fn test_weldr() {
 
 ## Command-line tool
 
-The weldr command-line tool ⚙ `weldr` is an executable to manipulate LDraw files and convert them to other formats (currently: glTF 2.0).
+The ⚙ `weldr` command-line tool is an executable to manipulate LDraw files and convert them to other formats (currently: glTF 2.0 only).
 
 Convert an LDraw file to a glTF 2.0 file:
 
@@ -66,7 +64,7 @@ You can get the list of commands with `weldr --help`. Currently only the `conver
 weldr convert [OPTIONS] gltf <INPUT>
 ```
 
-The official LDraw catalog of parts is available at <https://www.ldraw.org/library/updates/complete.zip>. When using it, use the `--catalog-path` to specify the location where it was downloaded, to allow ⚙ `weldr` to resolve files and all their sub-file references. By default the current working directory is used.
+The official LDraw catalog of parts is available at <https://library.ldraw.org/library/updates/complete.zip>. When using it, use the `--catalog-path` to specify the location where it was downloaded, to allow ⚙ `weldr` to resolve files and all their sub-file references. By default the current working directory is used.
 
 ## Copyrights
 
@@ -83,7 +81,7 @@ Licensed under either of
 
 at your option.
 
-### Contribution
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license,

--- a/bin/weldr/CHANGELOG.md
+++ b/bin/weldr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.4.0
+
+### Changed
+
+- Upgraded to `weldr` v0.5 for MPD support.
+- Bumped minimum rust version (MSRV) to 1.61.
+
 ## 0.3.0
 
 Project relicensed to a dual license MIT or Apache 2.0. See `LICENSE-APACHE2` and `LICENSE-MIT`.

--- a/bin/weldr/Cargo.toml
+++ b/bin/weldr/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "weldr-bin"
-version = "0.3.0"
+version = "0.4.0"
+rust-version = "1.61"
 authors = ["Jerome Humbert"]
 description = "A command-line tool to manipulate LDraw files (.ldr)"
 license = "MIT OR Apache-2.0"

--- a/bin/weldr/Cargo.toml
+++ b/bin/weldr/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/weldr.rs"
 doc = false
 
 [dependencies]
-weldr = { version = "0.4.0", path = "../../lib" }
+weldr = { version = "0.5.0", path = "../../lib" }
 ansi_term = "0.12"
 clap = "2.33"
 structopt = "0.3"

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.5.0
+
+### Added
+
+- Added support for multi-part documents (MPD extension).
+
+### Changed
+
+- Bumped minimum rust version (MSRV) to 1.61.
+
+### Fixed
+
+- Fixed a bug in hybrid file parsing, which discarded some drawing commands. (#32)
+
 ## 0.4.0
 
 Project relicensed to a dual license MIT or Apache 2.0. See `LICENSE-APACHE2` and `LICENSE-MIT`.

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "weldr"
-version = "0.4.0"
+version = "0.5.0"
+rust-version = "1.61"
 authors = ["Jerome Humbert"]
 description = "A Rust library to manage LDraw files (.ldr)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Update the `README`, fixing some broken links and incorrect terminologies.

Update both `CHANGELOG`s with new features.

Bump versions in `Cargo.toml` for both the library and bin tool, and add an explicit MSRV.